### PR TITLE
add quit condition and fix high CPU usage

### DIFF
--- a/service.c
+++ b/service.c
@@ -73,8 +73,9 @@ VOID ServiceStart(DWORD dwArgc, LPTSTR *lpszArgv)
 		goto cleanup;
 	}
 
-	while(1)
+	while(ssStatus.dwCurrentState == SERVICE_RUNNING)
 	{
+		Sleep(1000);//service loop code here
 	}
 
 cleanup:
@@ -88,6 +89,7 @@ cleanup:
 	{
 		CloseHandle(hEvents[1]);
 	}
+	exit(0);
 }
 
 VOID ServiceStop()


### PR DESCRIPTION
The original code cannot quit nomally from service.msc because of the while(1) loop. Of course the task manager can kill it. Then, nothing in while loop cause a high CPU usage, add some sleep to reduce. An exit(0) brings a clean shutdown that nothing will stay in task manager after stopped by service.msc. (This may not be the best practice)